### PR TITLE
Expose DeploymentTargetIoTCommon as library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,10 @@ let package = Package(
             targets: ["DeploymentTargetIoT"]
         ),
         .library(
+            name: "DeploymentTargetIoTCommon",
+            targets: ["DeploymentTargetIoTCommon"]
+        )
+        .library(
             name: "DeploymentTargetIoTRuntime",
             targets: ["DeploymentTargetIoTRuntime"]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(
             name: "DeploymentTargetIoTCommon",
             targets: ["DeploymentTargetIoTCommon"]
-        )
+        ),
         .library(
             name: "DeploymentTargetIoTRuntime",
             targets: ["DeploymentTargetIoTRuntime"]


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini Template open source project

SPDX-FileCopyrightText: 2021 Paul Schmiedmayer and the project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Expose DeploymentTargetIoTCommon as library

## :recycle: Current situation & Problem
`DeploymentTargetIoTCommon` is not accessible from outside the project. That means that for example `DeploymentDevice` cannot be brought into scope.

## :bulb: Proposed solution
Expose `DeploymentTargetIoTCommon` as library (like the other `DeploymentTargetIoT*`).

## :gear: Release Notes 
* Expose `DeploymentTargetIoTCommon` as library
