### PR TITLE
Support plain deployment

### DIFF
--- a/Sources/DeploymentTargetIoT/IoTDeploymentProvider.swift
+++ b/Sources/DeploymentTargetIoT/IoTDeploymentProvider.swift
@@ -204,18 +204,6 @@ public class IoTDeploymentProvider: DeploymentProvider { // swiftlint:disable:th
     }
     
     internal func deploy(_ result: DiscoveryResult, discovery: DeviceDiscovery) throws {
-        IoTContext.logger.debug("Cleaning up any leftover actions data in deployment directory")
-        
-        guard
-            // do nothing if there were no post actions
-            !result.foundEndDevices.isEmpty,
-            // do nothing if all post actions returned 0
-            result.foundEndDevices.values.contains(where: { $0 != 0 })
-        else {
-            IoTContext.logger.warning("No end devices were found for device \(String(describing: result.device.hostname))")
-            return
-        }
-        
         IoTContext.logger.info("Starting deployment to device \(String(describing: result.device.hostname))")
         
         let device = result.device


### PR DESCRIPTION
# Support plain deployment

## :recycle: Current situation & Problem
Given a web service that has handlers which are annotated with `.metadata(DeploymentDevice(.default))`. Currently, the provider does not allow a deployment this web service to a gateway that has no IoT devices. Handlers/groups that are annotated with the aforementioned meta data should be exported regardless of the presence of IoT devices and therefore the web service should be deployed as well.  

## :bulb: Proposed solution
Remove an unneeded check that prevents further actions if there have no IoT devices been found. This was intentionally designed to prevent unnecessary work, but with the introduction of `DeploymentDevice(.default)` this becomes redundant and can be removed.

## :gear: Release Notes 
- Enabling deployment of web services with default handlers by Remove an unneeded check that prevents further actions if there have no IoT devices been found.

### Testing
No tests were altered.

### Reviewer Nudging
@PSchmiedmayer Please tag this branch in the setup and verify if this fixes the issues 👍 
